### PR TITLE
Added scopeWithoutTag

### DIFF
--- a/src/TaggableTrait.php
+++ b/src/TaggableTrait.php
@@ -142,6 +142,17 @@ trait TaggableTrait
             $query->whereIn($type, $tags);
         });
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+      public static function scopeWithoutTag(Builder $query, $tags, $type = 'slug')
+    {
+        $tags = (new static)->prepareTags($tags);
+        return $query->whereDoesntHave('tags', function ($query) use ($type, $tags) {
+            $query->whereIn($type, $tags);
+        });
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
have the ability to search repositories against not having a tag:

->withoutTag('sometag')

// this came up because we needed away to grab content that is NOT tagged nsfw for non-logged in users