### PR TITLE
Add argument type declaration

### DIFF
--- a/src/TaggableTrait.php
+++ b/src/TaggableTrait.php
@@ -184,7 +184,7 @@ trait TaggableTrait
     /**
      * {@inheritdoc}
      */
-    public function setTags($tags, $type = 'name'): bool
+    public function setTags($tags, string $type = 'name'): bool
     {
         // Prepare the tags
         $tags = $this->prepareTags($tags);


### PR DESCRIPTION
The `TaggableInterface` declares that the second argument to `setTags()` is of type `string`, but this trait does not do the same, so an exception results when a class that implements `TaggableInterface` includes this trait (for example, `Platform\Pages\Models\Page`):

```php
class Page extends Model implements EntityInterface, TaggableInterface
{
    use EntityTrait, NamespacedEntityTrait, TaggableTrait;

    // ...
}
```

This results in:

```
Declaration of Platform\Pages\Models\Page::setTags($tags, $type = 'name'): bool must be compatible with Cartalyst\Tags\TaggableInterface::setTags($tags, string $type = 'name'): bool
```