### PR TITLE
Enable strict types

### DIFF
--- a/resources/migrations/2014_10_29_202547_migration_cartalyst_tags_create_tables.php
+++ b/resources/migrations/2014_10_29_202547_migration_cartalyst_tags_create_tables.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/src/IlluminateTag.php
+++ b/src/IlluminateTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/src/IlluminateTagged.php
+++ b/src/IlluminateTagged.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/src/TaggableInterface.php
+++ b/src/TaggableInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/src/TaggableTrait.php
+++ b/src/TaggableTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *
@@ -277,7 +279,7 @@ trait TaggableTrait
             $delimiter = preg_quote($this->getTagsDelimiter(), '#');
 
             $tags = array_map('trim',
-                preg_split("#[{$delimiter}]#", $tags, null, PREG_SPLIT_NO_EMPTY)
+                preg_split("#[{$delimiter}]#", $tags, -1, PREG_SPLIT_NO_EMPTY)
             );
         }
 

--- a/src/TagsServiceProvider.php
+++ b/src/TagsServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/tests/IlluminateTagTest.php
+++ b/tests/IlluminateTagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/tests/Stubs/Post.php
+++ b/tests/Stubs/Post.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/tests/Stubs/Post2.php
+++ b/tests/Stubs/Post2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *

--- a/tests/TaggableTraitTest.php
+++ b/tests/TaggableTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Part of the Tags package.
  *


### PR DESCRIPTION
This pull request enables strict types and also fixes a "bug" while enabling it on the `preg_split` call.